### PR TITLE
alacritty v0.13: update alacritty-theme to a TOML version as well

### DIFF
--- a/pkgs/data/themes/alacritty-theme/default.nix
+++ b/pkgs/data/themes/alacritty-theme/default.nix
@@ -6,13 +6,13 @@
 
 stdenvNoCC.mkDerivation (self: {
   name = "alacritty-theme";
-  version = "unstable-2023-11-07";
+  version = "unstable-2023-12-28";
 
   src = fetchFromGitHub {
     owner = "alacritty";
     repo = "alacritty-theme";
-    rev = "808b81b2e88884e8eca5d951b89f54983fa6c237";
-    hash = "sha256-g5tM6VBPLXin5s7X0PpzWOOGTEwHpVUurWOPqM/O13A=";
+    rev = "b7a59c92fd54a005893b99479fb0aa466a37a4b7";
+    hash = "sha256-UBWH4Q9MliqcolFq1tZrfRdzCkUO1pRn84qvZEVw8Gg=";
   };
 
   dontConfigure = true;


### PR DESCRIPTION
## Description of changes

alacritty-theme: unstable-2023-11-07 → unstable-2023-12-28
Necessary for alacritty v0.13, as the configuration language changed (TOML instead of YAML)


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested compilation of all packages that depend on this change (none)
- [x] Tested basic functionality of all binary files
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
